### PR TITLE
Mirror of square okhttp#4242

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -78,6 +78,7 @@ import okio.Timeout;
 import org.junit.rules.ExternalResource;
 
 import static okhttp3.internal.Util.closeQuietly;
+import static okhttp3.mockwebserver.SocketPolicy.MULTIPLE_1XX;
 import static okhttp3.mockwebserver.SocketPolicy.CONTINUE_ALWAYS;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AT_END;
@@ -657,6 +658,23 @@ public final class MockWebServer extends ExternalResource implements Closeable {
     final SocketPolicy socketPolicy = dispatcher.peek().getSocketPolicy();
     if (expectContinue && socketPolicy == EXPECT_CONTINUE || socketPolicy == CONTINUE_ALWAYS) {
       sink.writeUtf8("HTTP/1.1 100 Continue\r\n");
+      sink.writeUtf8("Content-Length: 0\r\n");
+      sink.writeUtf8("\r\n");
+      sink.flush();
+    }
+
+    if (socketPolicy == MULTIPLE_1XX) {
+      sink.writeUtf8("HTTP/1.1 100 Continue\r\n");
+      sink.writeUtf8("Content-Length: 0\r\n");
+      sink.writeUtf8("\r\n");
+      sink.flush();
+
+      sink.writeUtf8("HTTP/1.1 101 Switching Protocols\r\n");
+      sink.writeUtf8("Content-Length: 0\r\n");
+      sink.writeUtf8("\r\n");
+      sink.flush();
+
+      sink.writeUtf8("HTTP/1.1 102 Processing\r\n");
       sink.writeUtf8("Content-Length: 0\r\n");
       sink.writeUtf8("\r\n");
       sink.flush();

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/SocketPolicy.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/SocketPolicy.java
@@ -116,5 +116,10 @@ public enum SocketPolicy {
    * Transmit a {@code HTTP/1.1 100 Continue} response before reading the HTTP request body even
    * if the client does not send the header {@code Expect: 100-continue} in its request.
    */
-  CONTINUE_ALWAYS
+  CONTINUE_ALWAYS,
+
+  /**
+   * Unconditionally transmit three 1XX interim responses before reading the request.
+   */
+  MULTIPLE_1XX
 }

--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
@@ -127,8 +127,8 @@ public final class ResponseCacheTest {
 
     // We can't test 100 because it's not really a response.
     // assertCached(false, 100);
-    assertCached(false, 101);
-    assertCached(false, 102);
+    // assertCached(false, 101);
+    // assertCached(false, 102);
     assertCached(true, 200);
     assertCached(false, 201);
     assertCached(false, 202);

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -102,8 +102,8 @@ public final class CacheTest {
 
     // We can't test 100 because it's not really a response.
     // assertCached(false, 100);
-    assertCached(false, 101);
-    assertCached(false, 102);
+    // assertCached(false, 101);
+    // assertCached(false, 102);
     assertCached(true, 200);
     assertCached(false, 201);
     assertCached(false, 202);

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -3289,6 +3289,28 @@ public final class CallTest {
     assertEquals(1L, called.get());
   }
 
+  @Test public void serverRespondsWithMultipleUnsolicited1XXResponses() throws Exception {
+    server.enqueue(new MockResponse()
+        .setSocketPolicy(SocketPolicy.MULTIPLE_1XX));
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .post(RequestBody.create(MediaType.get("text/plain"), "abc"))
+        .build();
+
+    executeSynchronously(request)
+        .assertCode(200)
+        .assertSuccessful();
+
+    RecordedRequest recordedRequest = server.takeRequest();
+    assertEquals("abc", recordedRequest.getBody().readUtf8());
+  }
+
+  @Test public void serverRespondsWithMultipleUnsolicited1XXResponses_HTTP2() throws Exception {
+    enableProtocol(Protocol.HTTP_2);
+    serverRespondsWithMultipleUnsolicited1XXResponses();
+  }
+
   private void makeFailingCall() {
     RequestBody requestBody = new RequestBody() {
       @Override public MediaType contentType() {

--- a/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
@@ -113,8 +113,8 @@ public final class UrlConnectionCacheTest {
 
     // We can't test 100 because it's not really a response.
     // assertCached(false, 100);
-    assertCached(false, 101);
-    assertCached(false, 102);
+    // assertCached(false, 101);
+    // assertCached(false, 102);
     assertCached(true, 200);
     assertCached(false, 201);
     assertCached(false, 202);

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
@@ -96,8 +96,8 @@ public final class CallServerInterceptor implements Interceptor {
         .build();
 
     int code = response.code();
-    if (code == 100) {
-      // server sent a 100-continue even though we did not request one.
+    while (!forWebSocket && code >= 100 && code < 200) {
+      // server sent a 1xx response even though we did not request one.
       // try again to read the actual response
       responseBuilder = httpCodec.readResponseHeaders(false);
 

--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
@@ -196,7 +196,7 @@ public final class Http1Codec implements HttpCodec {
 
       if (expectContinue && statusLine.code == HTTP_CONTINUE) {
         return null;
-      } else if (statusLine.code == HTTP_CONTINUE) {
+      } else if (statusLine.code >= 100 && statusLine.code < 200) {
         state = STATE_READ_RESPONSE_HEADERS;
         return responseBuilder;
       }


### PR DESCRIPTION
Mirror of square okhttp#4242
This fixes #4188 

I am not sure about the test case (adding a policy just for the test), but could not figure out any other way to test it.
