### PR TITLE
Mirror of square okhttp#5076

### DIFF
--- a/okhttp/src/main/java/okhttp3/ConnectionSpec.kt
+++ b/okhttp/src/main/java/okhttp3/ConnectionSpec.kt
@@ -16,7 +16,6 @@
 package okhttp3
 
 import okhttp3.ConnectionSpec.Builder
-import okhttp3.internal.Util
 import okhttp3.internal.Util.concat
 import okhttp3.internal.Util.indexOf
 import okhttp3.internal.Util.intersect
@@ -88,7 +87,7 @@ class ConnectionSpec internal constructor(builder: Builder) {
     }
 
     val tlsVersionsIntersection = if (tlsVersions != null) {
-      intersect(Util.NATURAL_ORDER, sslSocket.enabledProtocols, tlsVersions)
+      intersect(naturalOrder(), sslSocket.enabledProtocols, tlsVersions)
     } else {
       sslSocket.enabledProtocols
     }
@@ -126,7 +125,7 @@ class ConnectionSpec internal constructor(builder: Builder) {
     }
 
     if (tlsVersions != null &&
-        !nonEmptyIntersection(Util.NATURAL_ORDER, tlsVersions, socket.enabledProtocols)) {
+        !nonEmptyIntersection(naturalOrder(), tlsVersions, socket.enabledProtocols)) {
       return false
     }
 

--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -69,8 +69,6 @@ object Util {
   /** GMT and UTC are equivalent for our purposes.  */
   @JvmField val UTC = TimeZone.getTimeZone("GMT")!!
 
-  val NATURAL_ORDER = Comparator<String> { a, b -> a.compareTo(b) }
-
   /**
    * Quick and dirty pattern to differentiate IP addresses from hostnames. This is an approximation
    * of Android's private InetAddress#isNumeric API.


### PR DESCRIPTION
Mirror of square okhttp#5076
This is a singleton, although not documented as such. The use of a function allows generics to play nice.

Once we're API 24+ we can use `Comparator.naturalOrder()`
