### PR TITLE
Mirror of square okhttp#5070

### DIFF
--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -1582,8 +1582,6 @@ public final class HttpOverHttp2Test {
   }
 
   /** https://github.com/square/okhttp/issues/4875 */
-  @Ignore(
-      "This often fails due to a NoSuchElementException thrown from RouteSelector.next(). Run it repeatedly to reproduce.")
   @Test
   public void shutdownAfterLateCoalescing() throws Exception {
     CountDownLatch latch = new CountDownLatch(2);


### PR DESCRIPTION
Mirror of square okhttp#5070
Otherwise we end up making multiple calls to retryCurrentRoute()
and if it returns true then false we can fail to find a route on
a retry.

Closes: https://github.com/square/okhttp/issues/4875
