### PR TITLE
Mirror of square okhttp#5092

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -153,11 +153,11 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
     val logBody = level == Level.BODY
     val logHeaders = logBody || level == Level.HEADERS
 
-    val requestBody = request.body()
+    val requestBody = request.body
 
     val connection = chain.connection()
     var requestStartMessage =
-        ("--> ${request.method()} ${request.url()}${if (connection != null) " " + connection.protocol() else ""}")
+        ("--> ${request.method} ${request.url}${if (connection != null) " " + connection.protocol() else ""}")
     if (!logHeaders && requestBody != null) {
       requestStartMessage += " (${requestBody.contentLength()}-byte body)"
     }
@@ -175,7 +175,7 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
         }
       }
 
-      val headers = request.headers()
+      val headers = request.headers
       var i = 0
       val count = headers.size
       while (i < count) {
@@ -189,11 +189,11 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
       }
 
       if (!logBody || requestBody == null) {
-        logger.log("--> END ${request.method()}")
-      } else if (bodyHasUnknownEncoding(request.headers())) {
-        logger.log("--> END ${request.method()} (encoded body omitted)")
+        logger.log("--> END ${request.method}")
+      } else if (bodyHasUnknownEncoding(request.headers)) {
+        logger.log("--> END ${request.method} (encoded body omitted)")
       } else if (requestBody.isDuplex()) {
-        logger.log("--> END ${request.method()} (duplex request body omitted)")
+        logger.log("--> END ${request.method} (duplex request body omitted)")
       } else {
         val buffer = Buffer()
         requestBody.writeTo(buffer)
@@ -204,10 +204,10 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
         logger.log("")
         if (buffer.isUtf8()) {
           logger.log(buffer.readString(charset))
-          logger.log("--> END ${request.method()} (${requestBody.contentLength()}-byte body)")
+          logger.log("--> END ${request.method} (${requestBody.contentLength()}-byte body)")
         } else {
           logger.log(
-              "--> END ${request.method()} (binary ${requestBody.contentLength()}-byte body omitted)")
+              "--> END ${request.method} (binary ${requestBody.contentLength()}-byte body omitted)")
         }
       }
     }
@@ -227,7 +227,7 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
     val contentLength = responseBody.contentLength()
     val bodySize = if (contentLength != -1L) "$contentLength-byte" else "unknown-length"
     logger.log(
-        "<-- ${response.code()}${if (response.message().isEmpty()) "" else ' ' + response.message()} ${response.request().url()} (${tookMs}ms${if (!logHeaders) ", $bodySize body" else ""})")
+        "<-- ${response.code()}${if (response.message().isEmpty()) "" else ' ' + response.message()} ${response.request().url} (${tookMs}ms${if (!logHeaders) ", $bodySize body" else ""})")
 
     if (logHeaders) {
       val headers = response.headers()

--- a/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.kt
+++ b/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.kt
@@ -30,7 +30,7 @@ class JavaNetAuthenticator : okhttp3.Authenticator {
   override fun authenticate(route: Route?, response: Response): Request? {
     val challenges = response.challenges()
     val request = response.request()
-    val url = request.url()
+    val url = request.url
     val proxyAuthorization = response.code() == 407
     val proxy = route?.proxy() ?: Proxy.NO_PROXY
 

--- a/okhttp/src/main/java/okhttp3/Cache.kt
+++ b/okhttp/src/main/java/okhttp3/Cache.kt
@@ -188,7 +188,7 @@ class Cache internal constructor(
   }
 
   internal fun get(request: Request): Response? {
-    val key = key(request.url())
+    val key = key(request.url)
     val snapshot: DiskLruCache.Snapshot = try {
       cache[key] ?: return null
     } catch (e: IOException) {
@@ -212,9 +212,9 @@ class Cache internal constructor(
   }
 
   internal fun put(response: Response): CacheRequest? {
-    val requestMethod = response.request().method()
+    val requestMethod = response.request().method
 
-    if (HttpMethod.invalidatesCache(response.request().method())) {
+    if (HttpMethod.invalidatesCache(response.request().method)) {
       try {
         remove(response.request())
       } catch (ignored: IOException) {
@@ -236,7 +236,7 @@ class Cache internal constructor(
     val entry = Entry(response)
     var editor: DiskLruCache.Editor? = null
     try {
-      editor = cache.edit(key(response.request().url())) ?: return null
+      editor = cache.edit(key(response.request().url)) ?: return null
       entry.writeTo(editor)
       return RealCacheRequest(editor)
     } catch (e: IOException) {
@@ -247,7 +247,7 @@ class Cache internal constructor(
 
   @Throws(IOException::class)
   internal fun remove(request: Request) {
-    cache.remove(key(request.url()))
+    cache.remove(key(request.url))
   }
 
   internal fun update(cached: Response, network: Response) {
@@ -559,9 +559,9 @@ class Cache internal constructor(
     }
 
     internal constructor(response: Response) {
-      this.url = response.request().url().toString()
+      this.url = response.request().url.toString()
       this.varyHeaders = response.varyHeaders()
-      this.requestMethod = response.request().method()
+      this.requestMethod = response.request().method
       this.protocol = response.protocol()
       this.code = response.code()
       this.message = response.message()
@@ -646,8 +646,8 @@ class Cache internal constructor(
     }
 
     fun matches(request: Request, response: Response): Boolean {
-      return url == request.url().toString() &&
-          requestMethod == request.method() &&
+      return url == request.url.toString() &&
+          requestMethod == request.method &&
           varyMatches(response, varyHeaders, request)
     }
 
@@ -781,7 +781,7 @@ class Cache internal constructor(
     fun Response.varyHeaders(): Headers {
       // Use the request headers sent over the network, since that's what the response varies on.
       // Otherwise OkHttp-supplied headers like "Accept-Encoding: gzip" may be lost.
-      val requestHeaders = networkResponse()!!.request().headers()
+      val requestHeaders = networkResponse()!!.request().headers
       val responseHeaders = headers()
       return varyHeaders(requestHeaders, responseHeaders)
     }

--- a/okhttp/src/main/java/okhttp3/RealCall.kt
+++ b/okhttp/src/main/java/okhttp3/RealCall.kt
@@ -101,7 +101,7 @@ internal class RealCall private constructor(
       this.callsPerHost = other.callsPerHost
     }
 
-    fun host(): String = originalRequest.url().host
+    fun host(): String = originalRequest.url.host
 
     fun request(): Request = originalRequest
 
@@ -161,7 +161,7 @@ internal class RealCall private constructor(
         " to " + redactedUrl())
   }
 
-  fun redactedUrl(): String = originalRequest.url().redact()
+  fun redactedUrl(): String = originalRequest.url.redact()
 
   @Throws(IOException::class)
   fun getResponseWithInterceptorChain(): Response {

--- a/okhttp/src/main/java/okhttp3/Response.kt
+++ b/okhttp/src/main/java/okhttp3/Response.kt
@@ -218,7 +218,7 @@ class Response internal constructor(
   }
 
   override fun toString() =
-      "Response{protocol=$protocol, code=$code, message=$message, url=${request.url()}}"
+      "Response{protocol=$protocol, code=$code, message=$message, url=${request.url}}"
 
   open class Builder {
     internal var request: Request? = null

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.kt
@@ -122,7 +122,7 @@ class CacheInterceptor(internal val cache: InternalCache?) : Interceptor {
         return cacheWritingResponse(cacheRequest, response)
       }
 
-      if (HttpMethod.invalidatesCache(networkRequest.method())) {
+      if (HttpMethod.invalidatesCache(networkRequest.method)) {
         try {
           cache.remove(networkRequest)
         } catch (ignored: IOException) {

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheStrategy.kt
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheStrategy.kt
@@ -131,7 +131,7 @@ class CacheStrategy internal constructor(
       val candidate = computeCandidate()
 
       // We're forbidden from using the network and the cache is insufficient.
-      if (candidate.networkRequest != null && request.cacheControl().onlyIfCached) {
+      if (candidate.networkRequest != null && request.cacheControl.onlyIfCached) {
         return CacheStrategy(null, null)
       }
 
@@ -157,7 +157,7 @@ class CacheStrategy internal constructor(
         return CacheStrategy(request, null)
       }
 
-      val requestCaching = request.cacheControl()
+      val requestCaching = request.cacheControl
       if (requestCaching.noCache || hasConditions(request)) {
         return CacheStrategy(request, null)
       }
@@ -216,7 +216,7 @@ class CacheStrategy internal constructor(
         else -> return CacheStrategy(request, null) // No condition! Make a regular request.
       }
 
-      val conditionalRequestHeaders = request.headers().newBuilder()
+      val conditionalRequestHeaders = request.headers.newBuilder()
       addHeaderLenient(conditionalRequestHeaders, conditionName, conditionValue!!)
 
       val conditionalRequest = request.newBuilder()
@@ -242,7 +242,7 @@ class CacheStrategy internal constructor(
         return if (delta > 0L) delta else 0L
       }
 
-      if (lastModified != null && cacheResponse.request().url().query == null) {
+      if (lastModified != null && cacheResponse.request().url.query == null) {
         // As recommended by the HTTP RFC and implemented in Firefox, the max age of a document
         // should be defaulted to 10% of the document's age at the time it was served. Default
         // expiration dates aren't used for URIs containing a query.
@@ -326,7 +326,7 @@ class CacheStrategy internal constructor(
       }
 
       // A 'no-store' directive on request or response prevents the response from being cached.
-      return !response.cacheControl().noStore && !request.cacheControl().noStore
+      return !response.cacheControl().noStore && !request.cacheControl.noStore
     }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/ConnectInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ConnectInterceptor.kt
@@ -32,7 +32,7 @@ class ConnectInterceptor(val client: OkHttpClient) : Interceptor {
     val transmitter = realChain.transmitter()
 
     // We need the network to satisfy this request. Possibly for validating a conditional GET.
-    val doExtensiveHealthChecks = request.method() != "GET"
+    val doExtensiveHealthChecks = request.method != "GET"
     val exchange = transmitter.newExchange(chain, doExtensiveHealthChecks)
 
     return realChain.proceed(request, transmitter, exchange)

--- a/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
@@ -67,7 +67,7 @@ class Exchange(
   @Throws(IOException::class)
   fun createRequestBody(request: Request, duplex: Boolean): Sink {
     this.isDuplex = duplex
-    val contentLength = request.body()!!.contentLength()
+    val contentLength = request.body!!.contentLength()
     eventListener.requestBodyStart(call)
     val rawRequestBody = codec.createRequestBody(request, contentLength)
     return RequestBodySink(rawRequestBody, contentLength)

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -229,7 +229,7 @@ class RealConnection(
     eventListener: EventListener
   ) {
     var tunnelRequest: Request = createTunnelRequest()
-    val url = tunnelRequest.url()
+    val url = tunnelRequest.url
     for (i in 0 until MAX_TUNNEL_ATTEMPTS) {
       connectSocket(connectTimeout, readTimeout, call, eventListener)
       tunnelRequest = createTunnel(readTimeout, writeTimeout, tunnelRequest, url)
@@ -416,7 +416,7 @@ class RealConnection(
       val tunnelCodec = Http1ExchangeCodec(null, null, source, sink)
       source.timeout().timeout(readTimeout.toLong(), MILLISECONDS)
       sink.timeout().timeout(writeTimeout.toLong(), MILLISECONDS)
-      tunnelCodec.writeRequest(nextRequest.headers(), requestLine)
+      tunnelCodec.writeRequest(nextRequest.headers, requestLine)
       tunnelCodec.finishRequest()
       val response = tunnelCodec.readResponseHeaders(false)!!
           .request(nextRequest)

--- a/okhttp/src/main/java/okhttp3/internal/connection/Transmitter.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Transmitter.kt
@@ -118,7 +118,7 @@ class Transmitter(
    */
   fun prepareToConnect(request: Request) {
     if (this.request != null) {
-      if (this.request!!.url().canReuseConnectionFor(request.url()) && exchangeFinder!!.hasRouteToTry()) {
+      if (this.request!!.url.canReuseConnectionFor(request.url) && exchangeFinder!!.hasRouteToTry()) {
         return // Already ready.
       }
       check(exchange == null)
@@ -131,7 +131,7 @@ class Transmitter(
 
     this.request = request
     this.exchangeFinder = ExchangeFinder(
-        this, connectionPool, createAddress(request.url()), call, eventListener)
+        this, connectionPool, createAddress(request.url), call, eventListener)
   }
 
   private fun createAddress(url: HttpUrl): Address {

--- a/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.kt
@@ -39,7 +39,7 @@ class BridgeInterceptor(private val cookieJar: CookieJar) : Interceptor {
     val userRequest = chain.request()
     val requestBuilder = userRequest.newBuilder()
 
-    val body = userRequest.body()
+    val body = userRequest.body
     if (body != null) {
       val contentType = body.contentType()
       if (contentType != null) {
@@ -57,7 +57,7 @@ class BridgeInterceptor(private val cookieJar: CookieJar) : Interceptor {
     }
 
     if (userRequest.header("Host") == null) {
-      requestBuilder.header("Host", userRequest.url().toHostHeader())
+      requestBuilder.header("Host", userRequest.url.toHostHeader())
     }
 
     if (userRequest.header("Connection") == null) {
@@ -72,7 +72,7 @@ class BridgeInterceptor(private val cookieJar: CookieJar) : Interceptor {
       requestBuilder.header("Accept-Encoding", "gzip")
     }
 
-    val cookies = cookieJar.loadForRequest(userRequest.url())
+    val cookies = cookieJar.loadForRequest(userRequest.url)
     if (cookies.isNotEmpty()) {
       requestBuilder.header("Cookie", cookieHeader(cookies))
     }
@@ -83,7 +83,7 @@ class BridgeInterceptor(private val cookieJar: CookieJar) : Interceptor {
 
     val networkResponse = chain.proceed(requestBuilder.build())
 
-    cookieJar.receiveHeaders(userRequest.url(), networkResponse.headers())
+    cookieJar.receiveHeaders(userRequest.url, networkResponse.headers())
 
     val responseBuilder = networkResponse.newBuilder()
         .request(userRequest)

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.kt
@@ -30,14 +30,14 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
     val realChain = chain as RealInterceptorChain
     val exchange = realChain.exchange()
     val request = realChain.request()
-    val requestBody = request.body()
+    val requestBody = request.body
     val sentRequestMillis = System.currentTimeMillis()
 
     exchange.writeRequestHeaders(request)
 
     var responseHeadersStarted = false
     var responseBuilder: Response.Builder? = null
-    if (HttpMethod.permitsRequestBody(request.method()) && requestBody != null) {
+    if (HttpMethod.permitsRequestBody(request.method) && requestBody != null) {
       // If there's a "Expect: 100-continue" header on the request, wait for a "HTTP/1.1 100
       // Continue" response before transmitting the request body. If we don't get that, return
       // what we did get (such as a 4xx response) without ever transmitting the request body.

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.kt
@@ -212,7 +212,7 @@ fun CookieJar.receiveHeaders(url: HttpUrl, headers: Headers) {
  */
 fun Response.promisesBody(): Boolean {
   // HEAD requests never yield a body regardless of the response headers.
-  if (request().method() == "HEAD") {
+  if (request().method == "HEAD") {
     return false
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.kt
@@ -94,7 +94,7 @@ class RealInterceptorChain(
     calls++
 
     // If we already have a stream, confirm that the incoming request will use it.
-    check(this.exchange == null || this.exchange.connection()!!.supportsUrl(request.url())) {
+    check(this.exchange == null || this.exchange.connection()!!.supportsUrl(request.url)) {
       "network interceptor ${interceptors[index - 1]} must retain the same host and port"
     }
 

--- a/okhttp/src/main/java/okhttp3/internal/http/RequestLine.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/RequestLine.kt
@@ -29,13 +29,13 @@ object RequestLine {
    */
   fun get(request: Request, proxyType: Proxy.Type): String {
     val result = StringBuilder()
-    result.append(request.method())
+    result.append(request.method)
     result.append(' ')
 
     if (includeAuthorityInRequestLine(request, proxyType)) {
-      result.append(request.url())
+      result.append(request.url)
     } else {
-      result.append(requestPath(request.url()))
+      result.append(requestPath(request.url))
     }
 
     result.append(" HTTP/1.1")

--- a/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
@@ -108,7 +108,7 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
         return response
       }
 
-      val followUpBody = followUp.body()
+      val followUpBody = followUp.body
       if (followUpBody != null && followUpBody.isOneShot()) {
         return response
       }
@@ -155,7 +155,7 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
   }
 
   private fun requestIsOneShot(e: IOException, userRequest: Request): Boolean {
-    val requestBody = userRequest.body()
+    val requestBody = userRequest.body
     return (requestBody != null && requestBody.isOneShot()) ||
         e is FileNotFoundException
   }
@@ -200,7 +200,7 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
   private fun followUpRequest(userResponse: Response, route: Route?): Request? {
     val responseCode = userResponse.code()
 
-    val method = userResponse.request().method()
+    val method = userResponse.request().method
     when (responseCode) {
       HTTP_PROXY_AUTH -> {
         val selectedProxy = route!!.proxy()
@@ -234,7 +234,7 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
           return null
         }
 
-        val requestBody = userResponse.request().body()
+        val requestBody = userResponse.request().body
         if (requestBody != null && requestBody.isOneShot()) {
           return null
         }
@@ -275,10 +275,10 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
 
     val location = userResponse.header("Location") ?: return null
     // Don't follow redirects to unsupported protocols.
-    val url = userResponse.request().url().resolve(location) ?: return null
+    val url = userResponse.request().url.resolve(location) ?: return null
 
     // If configured, don't follow redirects between SSL and non-SSL.
-    val sameScheme = url.scheme == userResponse.request().url().scheme
+    val sameScheme = url.scheme == userResponse.request().url.scheme
     if (!sameScheme && !client.followSslRedirects()) return null
 
     // Most redirects don't include a request body.
@@ -288,7 +288,7 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
       if (HttpMethod.redirectsToGet(method)) {
         requestBuilder.method("GET", null)
       } else {
-        val requestBody = if (maintainBody) userResponse.request().body() else null
+        val requestBody = if (maintainBody) userResponse.request().body else null
         requestBuilder.method(method, requestBody)
       }
       if (!maintainBody) {
@@ -301,7 +301,7 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
     // When redirecting across hosts, drop all authentication headers. This
     // is potentially annoying to the application layer since they have no
     // way to retain them.
-    if (!userResponse.request().url().canReuseConnectionFor(url)) {
+    if (!userResponse.request().url.canReuseConnectionFor(url)) {
       requestBuilder.removeHeader("Authorization")
     }
 

--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -93,7 +93,7 @@ class Http1ExchangeCodec(
 
   override fun createRequestBody(request: Request, contentLength: Long): Sink {
     return when {
-      request.body() != null && request.body()!!.isDuplex() -> throw ProtocolException(
+      request.body != null && request.body!!.isDuplex() -> throw ProtocolException(
           "Duplex connections are not supported for HTTP/1")
       request.isChunked() -> newChunkedSink() // Stream a request body of unknown length.
       contentLength != -1L -> newKnownLengthSink() // Stream a request body of a known length.
@@ -120,7 +120,7 @@ class Http1ExchangeCodec(
   override fun writeRequestHeaders(request: Request) {
     val requestLine = RequestLine.get(
         request, realConnection!!.route().proxy().type())
-    writeRequest(request.headers(), requestLine)
+    writeRequest(request.headers, requestLine)
   }
 
   override fun reportedContentLength(response: Response): Long {
@@ -134,7 +134,7 @@ class Http1ExchangeCodec(
   override fun openResponseBodySource(response: Response): Source {
     return when {
       !response.promisesBody() -> newFixedLengthSource(0)
-      response.isChunked() -> newChunkedSource(response.request().url())
+      response.isChunked() -> newChunkedSource(response.request().url)
       else -> {
         val contentLength = response.headersContentLength()
         if (contentLength != -1L) {

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2ExchangeCodec.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2ExchangeCodec.kt
@@ -75,7 +75,7 @@ class Http2ExchangeCodec(
   override fun writeRequestHeaders(request: Request) {
     if (stream != null) return
 
-    val hasRequestBody = request.body() != null
+    val hasRequestBody = request.body != null
     val requestHeaders = http2HeadersList(request)
     stream = connection.newStream(requestHeaders, hasRequestBody)
     // We may have been asked to cancel while creating the new stream and sending the request
@@ -158,15 +158,15 @@ class Http2ExchangeCodec(
         UPGRADE)
 
     fun http2HeadersList(request: Request): List<Header> {
-      val headers = request.headers()
+      val headers = request.headers
       val result = ArrayList<Header>(headers.size + 4)
-      result.add(Header(TARGET_METHOD, request.method()))
-      result.add(Header(TARGET_PATH, RequestLine.requestPath(request.url())))
+      result.add(Header(TARGET_METHOD, request.method))
+      result.add(Header(TARGET_PATH, RequestLine.requestPath(request.url)))
       val host = request.header("Host")
       if (host != null) {
         result.add(Header(TARGET_AUTHORITY, host)) // Optional.
       }
-      result.add(Header(TARGET_SCHEME, request.url().scheme))
+      result.add(Header(TARGET_SCHEME, request.url.scheme))
 
       for (i in 0 until headers.size) {
         // header names must be lowercase.

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
@@ -124,8 +124,8 @@ class RealWebSocket(
   private var awaitingPong = false
 
   init {
-    require("GET" == originalRequest.method()) {
-      "Request must be GET: ${originalRequest.method()}"
+    require("GET" == originalRequest.method) {
+      "Request must be GET: ${originalRequest.method}"
     }
 
     this.key = ByteArray(16).apply { random.nextBytes(this) }.toByteString().base64()
@@ -175,7 +175,7 @@ class RealWebSocket(
 
         // Process all web socket messages.
         try {
-          val name = "OkHttp WebSocket ${request.url().redact()}"
+          val name = "OkHttp WebSocket ${request.url.redact()}"
           initReaderAndWriter(name, streams)
           listener.onOpen(this@RealWebSocket, response)
           loopReader()

--- a/okhttp/src/test/java/okhttp3/RecordingExecutor.kt
+++ b/okhttp/src/test/java/okhttp3/RecordingExecutor.kt
@@ -33,7 +33,7 @@ internal class RecordingExecutor(
   }
 
   fun assertJobs(vararg expectedUrls: String) {
-    val actualUrls = calls.map { it.request().url().toString() }
+    val actualUrls = calls.map { it.request().url.toString() }
     assertThat(actualUrls).containsExactly(*expectedUrls)
   }
 
@@ -41,7 +41,7 @@ internal class RecordingExecutor(
     val i = calls.iterator()
     while (i.hasNext()) {
       val call = i.next()
-      if (call.request().url().toString() == url) {
+      if (call.request().url.toString() == url) {
         i.remove()
         dispatcherTest.dispatcher.finished(call)
         return

--- a/okhttp/src/test/java/okhttp3/RequestTest.java
+++ b/okhttp/src/test/java/okhttp3/RequestTest.java
@@ -158,6 +158,7 @@ public final class RequestTest {
         .url("https://square.com")
         .build();
     assertThat(request.headers("Cache-Control")).containsExactly("no-cache");
+    assertThat(request.cacheControl().noCache()).isTrue();
   }
 
   @Test public void emptyCacheControlClearsAllCacheControlHeaders() {


### PR DESCRIPTION
Mirror of square okhttp#5092
- define `<at>get:JvmName(...)` for the following vals in constructor instead of passing `builder: Builder`.
  - `url: HttpUrl`
  - `method: String`
  - `headers: Headers`
  - `body: RequestBody?`

- add `<at>Deprecated(...)` to the following functions.
  - `fun url(): HttpUrl`
  - `fun method(): String`
  - `fun headers(): Headers`
  - `fun body(): RequestBody?`
  - `fun cacheControl(): CacheControl`

- clean up code where `()`(parentheses) is unnecessarily used.
