### PR TITLE
Mirror of square okhttp#5124

### DIFF
--- a/okhttp-tls/src/main/java/okhttp3/tls/HandshakeCertificates.kt
+++ b/okhttp-tls/src/main/java/okhttp3/tls/HandshakeCertificates.kt
@@ -67,20 +67,49 @@ import javax.net.ssl.X509TrustManager
  *    roots private to an organization or service.
  */
 class HandshakeCertificates private constructor(
-  private val keyManager: X509KeyManager,
-  private val trustManager: X509TrustManager
+  @get:JvmName("keyManager") val keyManager: X509KeyManager,
+  @get:JvmName("trustManager") val trustManager: X509TrustManager
 ) {
+
+  @JvmName("-deprecated_keyManager")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "keyManager"),
+      level = DeprecationLevel.WARNING)
   fun keyManager(): X509KeyManager = keyManager
 
+  @JvmName("-deprecated_trustManager")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "trustManager"),
+      level = DeprecationLevel.WARNING)
   fun trustManager(): X509TrustManager = trustManager
 
-  fun sslSocketFactory(): SSLSocketFactory = sslContext().socketFactory
-
-  fun sslContext(): SSLContext {
-    return Platform.get().newSSLContext().apply {
-      init(arrayOf<KeyManager>(keyManager), arrayOf<TrustManager>(trustManager), SecureRandom())
+  @get:JvmName("sslSocketFactory") val sslSocketFactory: SSLSocketFactory
+    get() {
+      return sslContext.socketFactory
     }
-  }
+
+  @JvmName("-deprecated_sslSocketFactory")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "sslSocketFactory"),
+      level = DeprecationLevel.WARNING)
+  fun sslSocketFactory(): SSLSocketFactory = sslSocketFactory
+
+  @get:JvmName("sslContext") val sslContext: SSLContext
+    get() {
+      return Platform.get().newSSLContext().apply {
+        init(arrayOf<KeyManager>(keyManager), arrayOf<TrustManager>(trustManager), SecureRandom())
+      }
+    }
+
+  @JvmName("-deprecated_sslContext")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "sslContext"),
+      level = DeprecationLevel.WARNING)
+  fun sslContext(): SSLContext = sslContext
 
   class Builder {
     private var heldCertificate: HeldCertificate? = null
@@ -124,10 +153,20 @@ class HandshakeCertificates private constructor(
      * certificates. Applications that connect to a known set of servers may be able to mitigate
      * this problem with [certificate pinning][CertificatePinner].
      */
-    fun addPlatformTrustedCertificates() = apply {
-      val platformTrustManager = Platform.get().platformTrustManager()
-      Collections.addAll(trustedCertificates, *platformTrustManager.acceptedIssuers)
-    }
+    @get:JvmName("addPlatformTrustedCertificates") val addPlatformTrustedCertificates: Builder
+      get() {
+        return apply {
+          val platformTrustManager = Platform.get().platformTrustManager()
+          Collections.addAll(trustedCertificates, *platformTrustManager.acceptedIssuers)
+        }
+      }
+
+    @JvmName("-deprecated_sslSocketFactory")
+    @Deprecated(
+        message = "moved to val",
+        replaceWith = ReplaceWith(expression = "sslSocketFactory"),
+        level = DeprecationLevel.WARNING)
+    fun addPlatformTrustedCertificates(): Builder = addPlatformTrustedCertificates
 
     fun build(): HandshakeCertificates {
       val keyManager = newKeyManager(null, heldCertificate, *(intermediates ?: emptyArray()))


### PR DESCRIPTION
Mirror of square okhttp#5124
- define `<at>get:JvmName(...)` for the following vals in constructor.
  - `keyManager: X509KeyManager`
  - `trustManager: X509TrustManager`

- add `<at>Deprecated(...)` to the following functions.
  - `fun keyManager(): X509KeyManager`
  - `fun trustManager(): X509TrustManager`
  - `fun sslSocketFactory(): SSLSocketFactory`
  - `fun sslContext(): SSLContext`
