### PR TITLE
Mirror of square okhttp#5118

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -343,7 +343,7 @@ class RealConnection(
 
       // Configure the socket's ciphers, TLS versions, and extensions.
       val connectionSpec = connectionSpecSelector.configureSecureSocket(sslSocket)
-      if (connectionSpec.supportsTlsExtensions()) {
+      if (connectionSpec.supportsTlsExtensions) {
         Platform.get().configureTlsExtensions(sslSocket, address.url.host, address.protocols)
       }
 
@@ -375,7 +375,7 @@ class RealConnection(
           unverifiedHandshake.peerCertificates)
 
       // Success! Save the handshake and the ALPN protocol.
-      val maybeProtocol = if (connectionSpec.supportsTlsExtensions()) {
+      val maybeProtocol = if (connectionSpec.supportsTlsExtensions) {
         Platform.get().getSelectedProtocol(sslSocket)
       } else {
         null


### PR DESCRIPTION
Mirror of square okhttp#5118
Cont. #5115 

- define the following vals in constructor instead of passing `builder: Builder`.
  - `<at>get:JvmName("isTls") val isTls: Boolean`
  - `<at>get:JvmName("supportsTlsExtensions") val supportsTlsExtensions: Boolean`
  - `private val cipherSuitesAsString: Array<String>?`
  - `private val tlsVersionsAsString: Array<String>?`

- add `<at>Deprecated(...)` to the following functions.
  - `fun cipherSuites(): List<CipherSuite>?`
  - `fun tlsVersions(): List<TlsVersion>?`

- clean up code where `()`(parentheses) is unnecessarily used.
