### PR TITLE
Mirror of square okhttp#5158

### DIFF
--- a/UPGRADING_TO_OKHTTP_4.md
+++ b/UPGRADING_TO_OKHTTP_4.md
@@ -1,0 +1,45 @@
+Upgrading to OkHttp 4
+=====================
+
+SAM Conversions
+---------------
+
+When you use Java APIs from Kotlin you can operate on Java interfaces as if they were Kotlin
+lambdas. The [feature][kotlin_sam] is available for interfaces that define a Single Abstract Method
+(SAM).
+
+But when you use Kotlin APIs from Kotlin there's no automatic conversion. Code that used SAM lambdas
+with OkHttp 3 must use objects with OkHttp 4.
+
+Kotlin + OkHttp 3.x:
+
+```
+val client = OkHttpClient.Builder()
+    .dns { hostname -> InetAddress.getAllByName(hostname).toList() }
+    .build()
+```
+
+Kotlin + OkHttp 4.x
+
+```
+val client = OkHttpClient.Builder()
+    .dns(object : Dns {
+      override fun lookup(hostname: String) =
+          InetAddress.getAllByName(hostname).toList()
+    })
+    .build()
+```
+
+SAM conversion impacts these APIs:
+
+ * `Authenticator`
+ * `Dispatcher.setIdleCallback(Runnable)`
+ * `Dns`
+ * `EventListener.Factory`
+ * `HttpLoggingInterceptor.Logger`
+ * `LoggingEventListener.Factory`
+ * `OkHttpClient.Builder.eventListenerFactory(EventListener.Factory)`
+ * `OkHttpClient.Builder.hostnameVerifier(HostnameVerifier)`
+
+[kotlin_sam]: https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions
+

--- a/okcurl/src/main/java/okhttp3/curl/Main.kt
+++ b/okcurl/src/main/java/okhttp3/curl/Main.kt
@@ -173,7 +173,11 @@ class Main : Runnable {
       builder.hostnameVerifier(createInsecureHostnameVerifier())
     }
     if (verbose) {
-      val logger = HttpLoggingInterceptor.Logger { println(it) }
+      val logger = object : HttpLoggingInterceptor.Logger {
+        override fun log(message: String) {
+          println(message)
+        }
+      }
       builder.eventListenerFactory(LoggingEventListener.Factory(logger))
     }
     return builder.build()

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -109,14 +109,6 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
     fun log(message: String)
 
     companion object {
-      @JvmName("-deprecated_Logger")
-      @Deprecated(
-          message = "No SAM (single-abstract-method) conversions for Kotlin declarations",
-          level = DeprecationLevel.WARNING)
-      operator fun invoke(block: (message: String) -> Unit): Logger = object : Logger {
-        override fun log(message: String) = block(message)
-      }
-
       /** A [Logger] defaults output appropriate for the current platform. */
       @JvmField
       val DEFAULT: Logger = object : Logger {

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.kt
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.kt
@@ -150,8 +150,6 @@ class LoggingEventListener private constructor(
   open class Factory @JvmOverloads constructor(
     private val logger: HttpLoggingInterceptor.Logger = HttpLoggingInterceptor.Logger.DEFAULT
   ) : EventListener.Factory {
-    constructor(block: (string: String) -> Unit) : this(HttpLoggingInterceptor.Logger(block))
-
     override fun create(call: Call): EventListener = LoggingEventListener(logger)
   }
 }

--- a/okhttp/src/main/java/okhttp3/Authenticator.kt
+++ b/okhttp/src/main/java/okhttp3/Authenticator.kt
@@ -113,15 +113,5 @@ interface Authenticator {
     val NONE = object : Authenticator {
       override fun authenticate(route: Route?, response: Response): Request? = null
     }
-
-    @JvmName("-deprecated_Authenticator")
-    @Deprecated(
-        message = "No SAM (single-abstract-method) conversions for Kotlin declarations",
-        level = DeprecationLevel.WARNING)
-    operator fun invoke(
-      block: (route: Route?, response: Response) -> Request?
-    ): Authenticator = object : Authenticator {
-      override fun authenticate(route: Route?, response: Response) = block(route, response)
-    }
   }
 }

--- a/okhttp/src/main/java/okhttp3/Dispatcher.kt
+++ b/okhttp/src/main/java/okhttp3/Dispatcher.kt
@@ -234,12 +234,4 @@ class Dispatcher constructor() {
       replaceWith = ReplaceWith(expression = "executorService"),
       level = DeprecationLevel.WARNING)
   fun executorService(): ExecutorService = executorService
-
-  @JvmName("-deprecated_setIdleCallback")
-  @Deprecated(
-      message = "No SAM (single-abstract-method) conversions for Kotlin declarations",
-      level = DeprecationLevel.WARNING)
-  fun setIdleCallback(idleCallback: () -> Unit) = run {
-    this.idleCallback = Runnable { idleCallback() }
-  }
 }

--- a/okhttp/src/main/java/okhttp3/Dns.kt
+++ b/okhttp/src/main/java/okhttp3/Dns.kt
@@ -53,13 +53,5 @@ interface Dns {
         }
       }
     }
-
-    @JvmName("-deprecated_Dns")
-    @Deprecated(
-        message = "No SAM (single-abstract-method) conversions for Kotlin declarations",
-        level = DeprecationLevel.WARNING)
-    operator fun invoke(block: (String) -> List<InetAddress>): Dns = object : Dns {
-      override fun lookup(hostname: String): List<InetAddress> = block(hostname)
-    }
   }
 }

--- a/okhttp/src/main/java/okhttp3/EventListener.kt
+++ b/okhttp/src/main/java/okhttp3/EventListener.kt
@@ -346,16 +346,6 @@ abstract class EventListener {
      * from this method.**
      */
     fun create(call: Call): EventListener
-
-    companion object {
-      @JvmName("-deprecated_Factory")
-      @Deprecated(
-          message = "No SAM (single-abstract-method) conversions for Kotlin declarations",
-          level = DeprecationLevel.WARNING)
-      operator fun invoke(block: (call: Call) -> EventListener): Factory = object : Factory {
-        override fun create(call: Call) = block(call)
-      }
-    }
   }
 
   companion object {

--- a/okhttp/src/main/java/okhttp3/Interceptor.kt
+++ b/okhttp/src/main/java/okhttp3/Interceptor.kt
@@ -28,13 +28,20 @@ interface Interceptor {
   fun intercept(chain: Chain): Response
 
   companion object {
-    @JvmName("-deprecated_Interceptor")
-    @Deprecated(
-        message = "No SAM (single-abstract-method) conversions for Kotlin declarations",
-        level = DeprecationLevel.WARNING)
-    operator fun invoke(block: (chain: Chain) -> Response): Interceptor = object : Interceptor {
-      override fun intercept(chain: Chain) = block(chain)
-    }
+    /**
+     * Constructs an interceptor for a lambda. This compact syntax is most useful for inline
+     * interceptors.
+     *
+     * ```
+     * val interceptor = Interceptor { chain: Interceptor.Chain ->
+     *     chain.proceed(chain.request())
+     * }
+     * ```
+     */
+    inline operator fun invoke(crossinline block: (chain: Chain) -> Response): Interceptor =
+        object : Interceptor {
+          override fun intercept(chain: Chain) = block(chain)
+        }
   }
 
   interface Chain {

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.kt
@@ -40,7 +40,6 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 import javax.net.SocketFactory
 import javax.net.ssl.HostnameVerifier
-import javax.net.ssl.SSLSession
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
@@ -512,14 +511,9 @@ open class OkHttpClient internal constructor(
       interceptors += interceptor
     }
 
-    @JvmName("-deprecated_addInterceptor")
-    @Deprecated(
-        message = "No SAM (single-abstract-method) conversions for Kotlin declarations",
-        level = DeprecationLevel.WARNING)
-    fun addInterceptor(block: (chain: Interceptor.Chain) -> Response) =
-        addInterceptor(object : Interceptor {
-          override fun intercept(chain: Interceptor.Chain): Response = block(chain)
-        })
+    @JvmName("-addInterceptor") // Prefix with '-' to prevent ambiguous overloads from Java.
+    inline fun addInterceptor(crossinline block: (chain: Interceptor.Chain) -> Response) =
+        addInterceptor(Interceptor { chain -> block(chain) })
 
     /**
      * Returns a modifiable list of interceptors that observe a single network request and response.
@@ -532,14 +526,9 @@ open class OkHttpClient internal constructor(
       networkInterceptors += interceptor
     }
 
-    @JvmName("-deprecated_addNetworkInterceptor")
-    @Deprecated(
-        message = "No SAM (single-abstract-method) conversions for Kotlin declarations",
-        level = DeprecationLevel.WARNING)
-    fun addNetworkInterceptor(block: (chain: Interceptor.Chain) -> Response) =
-        addNetworkInterceptor(object : Interceptor {
-          override fun intercept(chain: Interceptor.Chain): Response = block(chain)
-        })
+    @JvmName("-addNetworkInterceptor") // Prefix with '-' to prevent ambiguous overloads from Java.
+    inline fun addNetworkInterceptor(crossinline block: (chain: Interceptor.Chain) -> Response) =
+        addNetworkInterceptor(Interceptor { chain -> block(chain) })
 
     /**
      * Configure a single client scoped listener that will receive all analytic events for this
@@ -560,15 +549,6 @@ open class OkHttpClient internal constructor(
     fun eventListenerFactory(eventListenerFactory: EventListener.Factory) = apply {
       this.eventListenerFactory = eventListenerFactory
     }
-
-    @JvmName("-deprecated_eventListenerFactory")
-    @Deprecated(
-        message = "No SAM (single-abstract-method) conversions for Kotlin declarations",
-        level = DeprecationLevel.WARNING)
-    fun eventListenerFactory(block: (call: Call) -> EventListener) =
-        eventListenerFactory(object : EventListener.Factory {
-          override fun create(call: Call) = block(call)
-        })
 
     /**
      * Configure this client to retry or not when a connectivity problem is encountered. By default,
@@ -808,13 +788,6 @@ open class OkHttpClient internal constructor(
     fun hostnameVerifier(hostnameVerifier: HostnameVerifier) = apply {
       this.hostnameVerifier = hostnameVerifier
     }
-
-    @JvmName("-deprecated_hostnameVerifier")
-    @Deprecated(
-        message = "No SAM (single-abstract-method) conversions for Kotlin declarations",
-        level = DeprecationLevel.WARNING)
-    fun hostnameVerifier(block: (String, SSLSession) -> Boolean) =
-        hostnameVerifier(HostnameVerifier { hostname, sslSession -> block(hostname, sslSession) })
 
     /**
      * Sets the certificate pinner that constrains which certificates are trusted. By default HTTPS

--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -17,6 +17,7 @@
 
 package okhttp3.internal
 
+import okhttp3.Call
 import okhttp3.EventListener
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
@@ -296,7 +297,9 @@ fun HttpUrl.canReuseConnectionFor(other: HttpUrl): Boolean = host == other.host 
     port == other.port &&
     scheme == other.scheme
 
-fun EventListener.asFactory() = EventListener.Factory { this }
+fun EventListener.asFactory() = object : EventListener.Factory {
+  override fun create(call: Call): EventListener = this@asFactory
+}
 
 infix fun Byte.and(mask: Int): Int = toInt() and mask
 infix fun Short.and(mask: Int): Int = toInt() and mask

--- a/okhttp/src/test/java/okhttp3/KotlinSourceCompatibilityTest.kt
+++ b/okhttp/src/test/java/okhttp3/KotlinSourceCompatibilityTest.kt
@@ -108,7 +108,6 @@ class KotlinSourceCompatibilityTest {
     var authenticator: Authenticator = object : Authenticator {
       override fun authenticate(route: Route?, response: Response): Request? = TODO()
     }
-    authenticator = Authenticator { route: Route?, response: Response -> TODO() }
   }
 
   @Test @Ignore
@@ -309,7 +308,6 @@ class KotlinSourceCompatibilityTest {
     val maxRequestsPerHost: Int = dispatcher.maxRequestsPerHost
     dispatcher.maxRequestsPerHost = 0
     val executorService: ExecutorService = dispatcher.executorService()
-    dispatcher.setIdleCallback { TODO() }
     dispatcher.idleCallback = object : Runnable {
       override fun run() {
         TODO()
@@ -336,7 +334,6 @@ class KotlinSourceCompatibilityTest {
     var dns: Dns = object : Dns {
       override fun lookup(hostname: String): List<InetAddress> = TODO()
     }
-    dns = Dns { it: String -> TODO() }
 
     val system: Dns = Dns.SYSTEM
   }
@@ -398,7 +395,6 @@ class KotlinSourceCompatibilityTest {
     var builder: EventListener.Factory = object : EventListener.Factory {
       override fun create(call: Call): EventListener = TODO()
     }
-    builder = EventListener.Factory { it: Call -> TODO() }
   }
 
   @Test @Ignore
@@ -502,7 +498,6 @@ class KotlinSourceCompatibilityTest {
     var logger: HttpLoggingInterceptor.Logger = object : HttpLoggingInterceptor.Logger {
       override fun log(message: String) = TODO()
     }
-    logger = HttpLoggingInterceptor.Logger { TODO() }
     val default: HttpLoggingInterceptor.Logger = HttpLoggingInterceptor.Logger.DEFAULT
   }
 
@@ -580,7 +575,7 @@ class KotlinSourceCompatibilityTest {
     var interceptor: Interceptor = object : Interceptor {
       override fun intercept(chain: Interceptor.Chain): Response = TODO()
     }
-    interceptor = Interceptor { it: Interceptor.Chain -> TODO() }
+    interceptor = Interceptor { chain: Interceptor.Chain -> chain.proceed(chain.request()) }
   }
 
   @Test @Ignore
@@ -868,7 +863,7 @@ class KotlinSourceCompatibilityTest {
     builder = builder.socketFactory(SocketFactory.getDefault())
     builder = builder.sslSocketFactory(localhost().sslSocketFactory(), localhost().trustManager())
     builder = builder.hostnameVerifier(newHostnameVerifier())
-    builder = builder.hostnameVerifier { hostname: String, session: SSLSession -> false }
+    builder = builder.hostnameVerifier(HostnameVerifier { hostname, session -> false })
     builder = builder.certificatePinner(CertificatePinner.DEFAULT)
     builder = builder.authenticator(Authenticator.NONE)
     builder = builder.proxyAuthenticator(Authenticator.NONE)
@@ -893,8 +888,6 @@ class KotlinSourceCompatibilityTest {
     builder = builder.eventListenerFactory(object : EventListener.Factory {
       override fun create(call: Call): EventListener = TODO()
     })
-    builder = builder.eventListenerFactory(LoggingEventListener.Factory { s -> TODO() })
-    builder = builder.eventListenerFactory { it: Call -> TODO() }
     val client: OkHttpClient = builder.build()
   }
 

--- a/okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt
+++ b/okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt
@@ -114,7 +114,6 @@ class KotlinSourceModernTest {
     var authenticator: Authenticator = object : Authenticator {
       override fun authenticate(route: Route?, response: Response): Request? = TODO()
     }
-    authenticator = Authenticator { route: Route?, response: Response -> TODO() }
   }
 
   @Test @Ignore
@@ -337,7 +336,6 @@ class KotlinSourceModernTest {
     var dns: Dns = object : Dns {
       override fun lookup(hostname: String): List<InetAddress> = TODO()
     }
-    dns = Dns { it: String -> TODO() }
 
     val system: Dns = Dns.SYSTEM
   }
@@ -399,7 +397,6 @@ class KotlinSourceModernTest {
     var builder: EventListener.Factory = object : EventListener.Factory {
       override fun create(call: Call): EventListener = TODO()
     }
-    builder = EventListener.Factory { it: Call -> TODO() }
   }
 
   @Test @Ignore
@@ -503,7 +500,6 @@ class KotlinSourceModernTest {
     var logger: HttpLoggingInterceptor.Logger = object : HttpLoggingInterceptor.Logger {
       override fun log(message: String) = TODO()
     }
-    logger = HttpLoggingInterceptor.Logger { TODO() }
     val default: HttpLoggingInterceptor.Logger = HttpLoggingInterceptor.Logger.DEFAULT
   }
 
@@ -885,8 +881,6 @@ class KotlinSourceModernTest {
     builder = builder.eventListenerFactory(object : EventListener.Factory {
       override fun create(call: Call): EventListener = TODO()
     })
-    builder = builder.eventListenerFactory(LoggingEventListener.Factory { s -> TODO() })
-    builder = builder.eventListenerFactory { it: Call -> TODO() }
     val client: OkHttpClient = builder.build()
   }
 


### PR DESCRIPTION
Mirror of square okhttp#5158
The ReplaceWith() on these doesn't work well.

For interceptors I expect the need to be common enough that I'm making these
new APIs that we'll keep going forward. This is for both creating interceptors
directly and as arguments to addInterceptor() and addNetworkInterceptor().
