### PR TITLE
Mirror of square okhttp#5242

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,12 +189,12 @@ workflows:
       - testjdk8alpn:
           filters:
             branches:
-              ignore:
-                - gh-pages
+              only: master
       - testjdk11:
           filters:
             branches:
-              only: master
+              ignore:
+                - gh-pages
       - testconscrypt:
           filters:
             branches:


### PR DESCRIPTION
Mirror of square okhttp#5242
Leaving checks on JDK 8 now, for baseline etc.  There is some unknown split for users between

JDK8 - no alpn, http/1.1
JDK8 with alpn-boot - http/2
JDK9+

Seems simpler to run with JDK11 on branch PRs.  JDK8 is probably most common in real world, but doesn't test out http/2.
