### PR TITLE
Mirror of square okhttp#5240

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -3376,6 +3376,10 @@ public final class CallTest {
         .post(body)
         .build();
 
+    client = client.newBuilder()
+        .dns(new DoubleInetAddressDns())
+        .build();
+
     executeSynchronously(request)
         .assertFailure(FileNotFoundException.class);
 

--- a/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
@@ -15,6 +15,7 @@
  */
 package okhttp3.internal.http;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.HttpRetryException;
@@ -224,7 +225,7 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
     if (!client.retryOnConnectionFailure()) return false;
 
     // We can't send the request body again.
-    if (requestSendStarted && userRequest.body() instanceof UnrepeatableRequestBody) return false;
+    if (requestSendStarted && requestIsUnrepeatable(e, userRequest)) return false;
 
     // This exception is fatal.
     if (!isRecoverable(e, requestSendStarted)) return false;
@@ -234,6 +235,11 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
 
     // For failure recovery, use the same route selector with a new connection.
     return true;
+  }
+
+  private boolean requestIsUnrepeatable(IOException e, Request userRequest) {
+    return userRequest.body() instanceof UnrepeatableRequestBody
+        || e instanceof FileNotFoundException;
   }
 
   private boolean isRecoverable(IOException e, boolean requestSendStarted) {


### PR DESCRIPTION
Mirror of square okhttp#5240
(cherry picked from commit b822c0d38638eab892f57956a278ba0d89304779)

I'm backporting this fix to OkHttp 3.12, because we had the same issue and we need compatibility with Android 4.4 (the original fix was made on 3.13 which is only for Android 5 and above).
