### PR TITLE
Mirror of square okhttp#5300

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.kt
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.kt
@@ -19,6 +19,7 @@ import okhttp3.Call
 import okhttp3.Connection
 import okhttp3.EventListener
 import okhttp3.Handshake
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
@@ -45,6 +46,14 @@ class LoggingEventListener private constructor(
     startNs = System.nanoTime()
 
     logWithTime("callStart: ${call.request()}")
+  }
+
+  override fun proxySelectStart(call: Call, url: HttpUrl) {
+    logWithTime("proxySelectStart: $url")
+  }
+
+  override fun proxySelectEnd(call: Call, url: HttpUrl, proxies: List<Proxy>) {
+    logWithTime("proxySelectEnd: $proxies")
   }
 
   override fun dnsStart(call: Call, domainName: String) {

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
@@ -74,6 +74,8 @@ public final class LoggingEventListenerTest {
 
     logRecorder
         .assertLogMatch("callStart: Request\\{method=GET, url=" + url + "\\}")
+        .assertLogMatch("proxySelectStart: " + url)
+        .assertLogMatch("proxySelectEnd: \\[DIRECT\\]")
         .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
         .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
@@ -105,6 +107,8 @@ public final class LoggingEventListenerTest {
 
     logRecorder
         .assertLogMatch("callStart: Request\\{method=POST, url=" + url + "\\}")
+        .assertLogMatch("proxySelectStart: " + url)
+        .assertLogMatch("proxySelectEnd: \\[DIRECT\\]")
         .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
         .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
@@ -188,6 +192,8 @@ public final class LoggingEventListenerTest {
 
     logRecorder
         .assertLogMatch("callStart: Request\\{method=GET, url=" + url + "\\}")
+        .assertLogMatch("proxySelectStart: " + url)
+        .assertLogMatch("proxySelectEnd: \\[DIRECT\\]")
         .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("callFailed: java.net.UnknownHostException: reason")
         .assertNoMoreLogs();
@@ -208,6 +214,8 @@ public final class LoggingEventListenerTest {
 
     logRecorder
         .assertLogMatch("callStart: Request\\{method=GET, url=" + url + "\\}")
+        .assertLogMatch("proxySelectStart: " + url)
+        .assertLogMatch("proxySelectEnd: \\[DIRECT\\]")
         .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
         .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
@@ -149,6 +149,8 @@ public final class LoggingEventListenerTest {
 
     logRecorder
         .assertLogMatch("callStart: Request\\{method=GET, url=" + url + "\\}")
+        .assertLogMatch("proxySelectStart: " + url)
+        .assertLogMatch("proxySelectEnd: \\[DIRECT\\]")
         .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
         .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")

--- a/okhttp-testing-support/src/main/java/okhttp3/ClientRuleEventListener.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/ClientRuleEventListener.kt
@@ -33,6 +33,14 @@ class ClientRuleEventListener(var logger: (String) -> Unit) : EventListener(),
     logWithTime("callStart: ${call.request()}")
   }
 
+  override fun proxySelectStart(call: Call, url: HttpUrl) {
+    logWithTime("proxySelectStart: $url")
+  }
+
+  override fun proxySelectEnd(call: Call, url: HttpUrl, proxies: List<Proxy>) {
+    logWithTime("proxySelectEnd: $proxies")
+  }
+
   override fun dnsStart(call: Call, domainName: String) {
     logWithTime("dnsStart: $domainName")
   }

--- a/okhttp/src/main/java/okhttp3/EventListener.kt
+++ b/okhttp/src/main/java/okhttp3/EventListener.kt
@@ -61,6 +61,42 @@ abstract class EventListener {
   }
 
   /**
+   * Invoked prior to a proxy selection.
+   *
+   * This will be invoked for route selection regardless of whether the client
+   * is configured with a single proxy, a proxy selector, or neither.
+   *
+   * @param url a URL with only the scheme, hostname, and port specified.
+   */
+  open fun proxySelectStart(
+    call: Call,
+    url: HttpUrl
+  ) {
+  }
+
+  /**
+   * Invoked after proxy selection.
+   *
+   * Note that the list of proxies is never null, but it may be a list containing
+   * only [Proxy.NO_PROXY]. This comes up in several situations:
+   *
+   * * If neither a proxy nor proxy selector is configured.
+   * * If the proxy is configured explicitly as [Proxy.NO_PROXY].
+   * * If the proxy selector returns only [Proxy.NO_PROXY].
+   * * If the proxy selector returns an empty list or null.
+   *
+   * Otherwise it lists the proxies in the order they will be attempted.
+   *
+   * @param url a URL with only the scheme, hostname, and port specified.
+   */
+  open fun proxySelectEnd(
+    call: Call,
+    url: HttpUrl,
+    proxies: List<@JvmSuppressWildcards Proxy>
+  ) {
+  }
+
+  /**
    * Invoked just prior to a DNS lookup. See [Dns.lookup].
    *
    * This can be invoked more than 1 time for a single [Call]. For example, if the response to the

--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.kt
@@ -94,6 +94,7 @@ class RouteSelector(
 
   /** Prepares the proxy servers to try. */
   private fun resetNextProxy(url: HttpUrl, proxy: Proxy?) {
+    eventListener.proxySelectStart(call, url)
     proxies = if (proxy != null) {
       // If the user specifies a proxy, try that and only that.
       listOf(proxy)
@@ -107,6 +108,7 @@ class RouteSelector(
       }
     }
     nextProxyIndex = 0
+    eventListener.proxySelectEnd(call, url, proxies)
   }
 
   /** Returns true if there's another proxy to try. */

--- a/okhttp/src/test/java/okhttp3/DuplexTest.java
+++ b/okhttp/src/test/java/okhttp3/DuplexTest.java
@@ -242,7 +242,7 @@ public final class DuplexTest {
     mockDuplexResponseBody.awaitSuccess();
 
     assertThat(listener.recordedEventTypes()).containsExactly(
-        "CallStart", "DnsStart", "DnsEnd", "ConnectStart",
+        "CallStart", "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd", "ConnectStart",
         "SecureConnectStart", "SecureConnectEnd", "ConnectEnd", "ConnectionAcquired",
         "RequestHeadersStart", "RequestHeadersEnd", "RequestBodyStart", "ResponseHeadersStart",
         "ResponseHeadersEnd", "ResponseBodyStart", "ResponseBodyEnd", "RequestBodyEnd",
@@ -342,7 +342,7 @@ public final class DuplexTest {
     mockDuplexResponseBody.awaitSuccess();
 
     assertThat(listener.recordedEventTypes()).containsExactly(
-        "CallStart", "DnsStart", "DnsEnd", "ConnectStart",
+        "CallStart", "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd", "ConnectStart",
         "SecureConnectStart", "SecureConnectEnd", "ConnectEnd", "ConnectionAcquired",
         "RequestHeadersStart", "RequestHeadersEnd", "RequestBodyStart", "ResponseHeadersStart",
         "ResponseHeadersEnd", "ResponseBodyStart", "ResponseBodyEnd", "RequestHeadersStart",

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -112,7 +112,8 @@ public final class EventListenerTest {
     assertThat(response.body().string()).isEqualTo("abc");
     response.body().close();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
@@ -142,7 +143,8 @@ public final class EventListenerTest {
 
     completionLatch.await();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
@@ -163,7 +165,8 @@ public final class EventListenerTest {
       assertThat(expected.getMessage()).isIn("timeout", "Read timed out");
     }
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseFailed", "ConnectionReleased",
         "CallFailed");
@@ -191,7 +194,8 @@ public final class EventListenerTest {
       assertThat(expected.getMessage()).isEqualTo("unexpected end of stream");
     }
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseFailed", "ConnectionReleased", "CallFailed");
@@ -211,7 +215,8 @@ public final class EventListenerTest {
       assertThat(expected.getMessage()).isEqualTo("Canceled");
     }
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "CallFailed");
+    assertThat(listener.recordedEventTypes())
+        .containsExactly("CallStart", "ProxySelectStart", "ProxySelectEnd", "CallFailed");
   }
 
   private void assertSuccessfulEventOrder(Matcher<Response> responseMatcher) throws IOException {
@@ -226,7 +231,8 @@ public final class EventListenerTest {
     assumeThat(response, responseMatcher);
 
     assertThat(listener.recordedEventTypes()).containsExactly(
-        "CallStart", "DnsStart", "DnsEnd", "ConnectStart",
+        "CallStart", "ProxySelectStart", "ProxySelectEnd",
+        "DnsStart", "DnsEnd", "ConnectStart",
         "SecureConnectStart", "SecureConnectEnd", "ConnectEnd", "ConnectionAcquired",
         "RequestHeadersStart", "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd",
         "ResponseBodyStart", "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
@@ -250,7 +256,8 @@ public final class EventListenerTest {
     Response response = call.execute();
     response.close();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "ConnectionAcquired",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "ConnectionAcquired",
         "RequestHeadersStart", "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd",
         "ResponseBodyStart", "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
   }
@@ -911,7 +918,8 @@ public final class EventListenerTest {
     Response response = call.execute();
     response.body().close();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
@@ -928,7 +936,8 @@ public final class EventListenerTest {
     Response response = call.execute();
     response.body().close();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
@@ -946,7 +955,8 @@ public final class EventListenerTest {
     Response response = call.execute();
     response.body().close();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
@@ -1068,7 +1078,7 @@ public final class EventListenerTest {
     }
 
     assertThat(listener.recordedEventTypes()).containsExactly(
-        "CallStart", "DnsStart", "DnsEnd", "ConnectStart",
+        "CallStart", "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd", "ConnectStart",
         "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd",
         "RequestBodyStart", "RequestFailed", "ConnectionReleased", "CallFailed");
   }
@@ -1129,7 +1139,8 @@ public final class EventListenerTest {
     assertThat(response.body().string()).isEqualTo("abc");
     response.body().close();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
@@ -1169,7 +1180,8 @@ public final class EventListenerTest {
     Call call = client.newCall(new Request.Builder().url(server.url("/")).build());
     call.execute();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseBodyEnd", "RequestHeadersStart", "RequestHeadersEnd", "ResponseHeadersStart",
@@ -1189,10 +1201,12 @@ public final class EventListenerTest {
     Call call = client.newCall(new Request.Builder().url(server.url("/")).build());
     call.execute();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
-        "ResponseBodyEnd", "ConnectionReleased", "DnsStart", "DnsEnd", "ConnectStart", "ConnectEnd",
+        "ResponseBodyEnd", "ConnectionReleased", "ProxySelectStart", "ProxySelectEnd",
+        "DnsStart", "DnsEnd", "ConnectStart", "ConnectEnd",
         "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd", "ResponseHeadersStart",
         "ResponseHeadersEnd", "ResponseBodyStart", "ResponseBodyEnd", "ConnectionReleased",
         "CallEnd");
@@ -1215,7 +1229,8 @@ public final class EventListenerTest {
     Response response = call.execute();
     assertThat(response.body().string()).isEqualTo("b");
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "DnsStart", "DnsEnd",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+        "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseBodyEnd", "RequestHeadersStart", "RequestHeadersEnd", "ResponseHeadersStart",
@@ -1259,7 +1274,7 @@ public final class EventListenerTest {
     call.execute();
 
     assertThat(listener.recordedEventTypes()).containsExactly(
-        "CallStart", "DnsStart", "DnsEnd", "ConnectStart",
+        "CallStart", "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd", "ConnectStart",
         "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd",
         "ResponseHeadersStart", "RequestBodyStart", "RequestBodyEnd", "ResponseHeadersEnd",
         "ResponseBodyStart", "ResponseBodyEnd", "ConnectionReleased", "CallEnd");

--- a/okhttp/src/test/java/okhttp3/RecordingEventListener.java
+++ b/okhttp/src/test/java/okhttp3/RecordingEventListener.java
@@ -24,6 +24,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,6 +80,15 @@ public class RecordingEventListener extends EventListener {
     }
 
     eventSequence.offer(e);
+  }
+
+  @Override public void proxySelectStart(@NotNull Call call, @NotNull HttpUrl url) {
+    logEvent(new ProxySelectStart(call, url));
+  }
+
+  @Override public void proxySelectEnd(@NotNull Call call, @NotNull HttpUrl url,
+      @NotNull List<Proxy> proxies) {
+    logEvent(new ProxySelectEnd(call, url, proxies));
   }
 
   @Override public void dnsStart(Call call, String domainName) {
@@ -205,6 +215,24 @@ public class RecordingEventListener extends EventListener {
 
     public @Nullable CallEvent closes() {
       return null;
+    }
+  }
+
+  static final class ProxySelectStart extends CallEvent {
+    final HttpUrl url;
+
+    ProxySelectStart(Call call, HttpUrl url) {
+      super(call, url);
+      this.url = url;
+    }
+  }
+
+  static final class ProxySelectEnd extends CallEvent {
+    final HttpUrl url;
+
+    ProxySelectEnd(Call call, HttpUrl url, List<Proxy> proxies) {
+      super(call, url, proxies);
+      this.url = url;
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/RecordingEventListener.java
+++ b/okhttp/src/test/java/okhttp3/RecordingEventListener.java
@@ -24,7 +24,6 @@ import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import javax.annotation.Nullable;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -82,12 +81,12 @@ public class RecordingEventListener extends EventListener {
     eventSequence.offer(e);
   }
 
-  @Override public void proxySelectStart(@NotNull Call call, @NotNull HttpUrl url) {
+  @Override public void proxySelectStart(Call call, HttpUrl url) {
     logEvent(new ProxySelectStart(call, url));
   }
 
-  @Override public void proxySelectEnd(@NotNull Call call, @NotNull HttpUrl url,
-      @NotNull List<Proxy> proxies) {
+  @Override public void proxySelectEnd(Call call, HttpUrl url,
+      List<Proxy> proxies) {
     logEvent(new ProxySelectEnd(call, url, proxies));
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -70,7 +70,6 @@ import okio.Buffer;
 import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -1603,7 +1602,7 @@ public final class HttpOverHttp2Test {
     client = client.newBuilder().eventListener(new EventListener() {
       int callCount;
 
-      @Override public void connectionAcquired(@NotNull Call call, @NotNull Connection connection) {
+      @Override public void connectionAcquired(Call call, Connection connection) {
         try {
           if (callCount++ == 1) {
             server.shutdown();

--- a/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java
@@ -104,7 +104,7 @@ public final class PrintEvents {
     }
 
     @Override public void proxySelectEnd(@NotNull Call call, @NotNull HttpUrl url,
-        @NotNull List<? extends Proxy> proxies) {
+        @NotNull List<Proxy> proxies) {
       printEvent("proxySelectEnd");
     }
 

--- a/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java
@@ -26,11 +26,13 @@ import okhttp3.Callback;
 import okhttp3.Connection;
 import okhttp3.EventListener;
 import okhttp3.Handshake;
+import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.jetbrains.annotations.NotNull;
 
 public final class PrintEvents {
   private final OkHttpClient client = new OkHttpClient.Builder()
@@ -95,6 +97,15 @@ public final class PrintEvents {
     private void printEvent(String name) {
       long elapsedNanos = System.nanoTime() - callStartNanos;
       System.out.printf("%04d %.3f %s%n", callId, elapsedNanos / 1000000000d, name);
+    }
+
+    @Override public void proxySelectStart(@NotNull Call call, @NotNull HttpUrl url) {
+      printEvent("proxySelectStart");
+    }
+
+    @Override public void proxySelectEnd(@NotNull Call call, @NotNull HttpUrl url,
+        @NotNull List<? extends Proxy> proxies) {
+      printEvent("proxySelectEnd");
     }
 
     @Override public void callStart(Call call) {

--- a/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java
@@ -32,7 +32,6 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.jetbrains.annotations.NotNull;
 
 public final class PrintEvents {
   private final OkHttpClient client = new OkHttpClient.Builder()
@@ -99,12 +98,11 @@ public final class PrintEvents {
       System.out.printf("%04d %.3f %s%n", callId, elapsedNanos / 1000000000d, name);
     }
 
-    @Override public void proxySelectStart(@NotNull Call call, @NotNull HttpUrl url) {
+    @Override public void proxySelectStart(Call call, HttpUrl url) {
       printEvent("proxySelectStart");
     }
 
-    @Override public void proxySelectEnd(@NotNull Call call, @NotNull HttpUrl url,
-        @NotNull List<Proxy> proxies) {
+    @Override public void proxySelectEnd(Call call, HttpUrl url, List<Proxy> proxies) {
       printEvent("proxySelectEnd");
     }
 

--- a/samples/guide/src/main/java/okhttp3/recipes/PrintEventsNonConcurrent.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/PrintEventsNonConcurrent.java
@@ -24,10 +24,12 @@ import okhttp3.Call;
 import okhttp3.Connection;
 import okhttp3.EventListener;
 import okhttp3.Handshake;
+import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This prints events for a single in-flight call. It won't work for multiple concurrent calls
@@ -74,6 +76,15 @@ public final class PrintEventsNonConcurrent {
 
     @Override public void callStart(Call call) {
       printEvent("callStart");
+    }
+
+    @Override public void proxySelectStart(@NotNull Call call, @NotNull HttpUrl url) {
+      printEvent("proxySelectStart");
+    }
+
+    @Override public void proxySelectEnd(@NotNull Call call, @NotNull HttpUrl url,
+        @NotNull List<? extends Proxy> proxies) {
+      printEvent("proxySelectEnd");
     }
 
     @Override public void dnsStart(Call call, String domainName) {

--- a/samples/guide/src/main/java/okhttp3/recipes/PrintEventsNonConcurrent.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/PrintEventsNonConcurrent.java
@@ -83,7 +83,7 @@ public final class PrintEventsNonConcurrent {
     }
 
     @Override public void proxySelectEnd(@NotNull Call call, @NotNull HttpUrl url,
-        @NotNull List<? extends Proxy> proxies) {
+        @NotNull List<Proxy> proxies) {
       printEvent("proxySelectEnd");
     }
 

--- a/samples/guide/src/main/java/okhttp3/recipes/PrintEventsNonConcurrent.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/PrintEventsNonConcurrent.java
@@ -29,7 +29,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * This prints events for a single in-flight call. It won't work for multiple concurrent calls
@@ -78,12 +77,11 @@ public final class PrintEventsNonConcurrent {
       printEvent("callStart");
     }
 
-    @Override public void proxySelectStart(@NotNull Call call, @NotNull HttpUrl url) {
+    @Override public void proxySelectStart(Call call, HttpUrl url) {
       printEvent("proxySelectStart");
     }
 
-    @Override public void proxySelectEnd(@NotNull Call call, @NotNull HttpUrl url,
-        @NotNull List<Proxy> proxies) {
+    @Override public void proxySelectEnd(Call call, HttpUrl url, List<Proxy> proxies) {
       printEvent("proxySelectEnd");
     }
 


### PR DESCRIPTION
Mirror of square okhttp#5300
Since proxies are either a no-op, or a real wild west of oh-my-god what the hell were the network admins thinking, log the events around proxies.
