### PR TITLE
Mirror of square okhttp#5460

### DIFF
--- a/okhttp/src/test/java/okhttp3/CallTest.java
+++ b/okhttp/src/test/java/okhttp3/CallTest.java
@@ -2318,7 +2318,7 @@ public final class CallTest {
     call.cancel();
     latch.countDown();
 
-    callback.await(server.url("/a")).assertFailure("Canceled", "Socket closed");
+    callback.await(server.url("/a")).assertFailure("Canceled", "Socket closed", "Socket is closed");
   }
 
   @Test public void cancelAll() throws Exception {
@@ -2327,7 +2327,7 @@ public final class CallTest {
         .build());
     call.enqueue(callback);
     client.dispatcher().cancelAll();
-    callback.await(server.url("/")).assertFailure("Canceled", "Socket closed");
+    callback.await(server.url("/")).assertFailure("Canceled", "Socket closed", "Socket is closed");
   }
 
   @Test


### PR DESCRIPTION
Mirror of square okhttp#5460
Can come from here

```
Caused by: java.net.SocketException: Socket is closed
        at sun.security.ssl.SSLSocketImpl.checkEOF(SSLSocketImpl.java:1542)
```

But I had this from some variant of local builds, not sure it's this one above.
