### PR TITLE
Mirror of square okhttp#5434

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.kt
@@ -178,7 +178,7 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
 
   @Synchronized internal fun updateConnectionFlowControl(read: Long) {
     readBytesTotal += read
-    val readBytesToAcknowledge = (readBytesTotal - readBytesAcknowledged)
+    val readBytesToAcknowledge = readBytesTotal - readBytesAcknowledged
     if (readBytesToAcknowledge >= okHttpSettings.initialWindowSize / 2) {
       writeWindowUpdateLater(0, readBytesToAcknowledge)
       readBytesAcknowledged += readBytesToAcknowledge


### PR DESCRIPTION
Mirror of square okhttp#5434
We had a bug where a race between FramingSource.receive() and
FramingSource.close() could cause newly-received bytes to be
absent from the flow control window. If this happens enough then
eventually the connection will stall.
